### PR TITLE
AS-11909 Monero Integrated Addresses

### DIFF
--- a/src/validators/MoneroValidator.js
+++ b/src/validators/MoneroValidator.js
@@ -6,8 +6,9 @@ import SUPPORTED_CURRENCIES from '../supportedCurrencies';
  */
 export default class MoneroValidator extends RegExpValidator {
   constructor() {
-    super([
-      SUPPORTED_CURRENCIES.monero,
-    ], /^4([0-9]|[A-B])([0-9a-zA-Z]){93}$/);
+    super(
+      [SUPPORTED_CURRENCIES.monero],
+      /^4([0-9]|[A-B])([0-9a-zA-Z]){93}$|^4([0-9]|[A-B])([0-9a-zA-Z]){104}$/
+    );
   }
 }


### PR DESCRIPTION
See this link
https://web.getmonero.org/resources/moneropedia/address.html

A monero address can be 106 or 95 characters long. Once again front end validation to the rescue from errors that we would have found out about from the server if this was actually an invalid address...